### PR TITLE
Fix return type of fgetc.

### DIFF
--- a/src/file_line_endings.c
+++ b/src/file_line_endings.c
@@ -14,8 +14,8 @@ SEXP brio_file_line_endings(SEXP path) {
     error("Could not open file: %s", path_c);
   }
 
-  char c;
-  char prev_c = '\0';
+  int c;
+  int prev_c = '\0';
   while ((c = fgetc(fp)) != EOF) {
     if (c == '\n') {
       if (prev_c == '\r') {


### PR DESCRIPTION
On x86, this seems to work by fluke, but on other systems, it does not work because `(char)EOF` never equals `EOF`, causing an infinite loop.

See for example, [this scratch build](https://koji.fedoraproject.org/koji/taskinfo?taskID=50962920) which I had to cancel as everything but x86_64 and i686 are stuck, whereas the [patched build works](https://koji.fedoraproject.org/koji/taskinfo?taskID=50979291).