### PR TITLE
Fix non-ASCII file names on older R Windows

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # brio (development version)
 
+* Input filenames are now automatically converted to UTF-8 from the native encoding (@gaborcsardi, #15)
+
 * `read_file_raw()` now closes file handles (@pbarber, #16)
 
 # brio 1.1.1

--- a/R/file_line_endings.R
+++ b/R/file_line_endings.R
@@ -18,5 +18,5 @@
 #' unlink(c(tf1, tf2))
 file_line_endings <- function(path) {
   path <- normalizePath(path, mustWork = TRUE)
-  .Call(brio_file_line_endings, path)
+  .Call(brio_file_line_endings, enc2utf8(path))
 }

--- a/R/read_file.R
+++ b/R/read_file.R
@@ -16,5 +16,5 @@
 #' identical(data, rawToChar(data_raw))
 read_file <- function(path) {
   path <- normalizePath(path, mustWork = TRUE)
-  .Call(brio_read_file, path)
+  .Call(brio_read_file, enc2utf8(path))
 }

--- a/R/read_file_raw.R
+++ b/R/read_file_raw.R
@@ -2,5 +2,5 @@
 #' @export
 read_file_raw <- function(path) {
   path <- normalizePath(path, mustWork = TRUE)
-  .Call(brio_read_file_raw, path)
+  .Call(brio_read_file_raw, enc2utf8(path))
 }

--- a/R/read_lines.R
+++ b/R/read_lines.R
@@ -15,5 +15,5 @@
 read_lines <- function(path, n = -1) {
   path <- normalizePath(path, mustWork = TRUE)
   n <- as.integer(n)
-  .Call(brio_read_lines, path, n)
+  .Call(brio_read_lines, enc2utf8(path), n)
 }

--- a/R/write_file.R
+++ b/R/write_file.R
@@ -27,5 +27,5 @@ write_file <- function(text, path) {
   text <- enc2utf8(text)
   path <- normalizePath(path, mustWork = FALSE)
 
-  invisible(.Call(brio_write_file, text, path))
+  invisible(.Call(brio_write_file, text, enc2utf8(path)))
 }

--- a/R/write_lines.R
+++ b/R/write_lines.R
@@ -29,5 +29,5 @@ write_lines <- function(text, path, eol = "\n") {
   text <- enc2utf8(text)
   path <- normalizePath(path, mustWork = FALSE)
 
-  invisible(.Call(brio_write_lines, text, path, eol))
+  invisible(.Call(brio_write_lines, text, enc2utf8(path), eol))
 }

--- a/tests/testthat/test-utf8.R
+++ b/tests/testthat/test-utf8.R
@@ -1,0 +1,16 @@
+
+test_that("UTF-8 file names", {
+  skip_on_cran()
+  tmp <- tempfile()
+  on.exit(unlink(tmp, recursive = TRUE), add = TRUE)
+  dir.create(tmp)
+  str <- "xx\xfcxx"
+  Encoding(str) <- "latin1"
+  write_lines(str, file.path(tmp, str))
+  expect_true(file.exists(file.path(tmp, str)))
+  str2 <- read_lines(file.path(tmp, str))
+  expect_identical(
+    charToRaw(enc2utf8(str2)),
+    charToRaw(str2)
+  )
+})


### PR DESCRIPTION
`normalizePath()` on R 3.4 and before converts the
path to the native encoding, apparently. (Nothing in
the docs about this.)

The C code of brio assumes that paths are in UTF-8,
so we need to explicitly convert them, for that to
hold on older R versions.

Tested from R 3.3 to R 4.1.