### PR TITLE
Fix for file left open after raw read

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # brio (development version)
 
+* `read_file_raw()` now closes file handles (@pbarber, #16)
+
 # brio 1.1.1
 
 * `file_line_endings()` now works as expected on ARM systems (#8)

--- a/src/read_file_raw.c
+++ b/src/read_file_raw.c
@@ -19,6 +19,7 @@ SEXP brio_read_file_raw(SEXP path) {
   rewind(fp);
 
   if (file_size == 0) {
+    fclose(fp);
     return allocVector(RAWSXP, 0);
   }
 
@@ -28,8 +29,11 @@ SEXP brio_read_file_raw(SEXP path) {
   read_buf[file_size] = '\0';
 
   if ((fread(read_buf, 1, file_size, fp)) <= 0) {
+    fclose(fp);
     error("Error reading file: %s", path_c);
   };
+
+  fclose(fp);
 
   SEXP ans;
   PROTECT(ans = allocVector(RAWSXP, file_size));


### PR DESCRIPTION
Whilst writing package tests using [testthat](https://testthat.r-lib.org/), I found that the [snapshot_review function](https://testthat.r-lib.org/reference/snapshot_review.html) would not update the snapshot files when I selected Accept due to a file handle being left open. I traced this back to the use of the [brio::read_file_raw call](https://github.com/r-lib/testthat/blob/47935141d430e002070a95dd8af6dbf70def0994/R/snapshot-file.R#L188) within testthat's binary file comparison function.

This can be tested by hand by:

1. Choose any file and check that you can rename it in your OS of choice (in my case Windows)
2. Run `brio::read_file_raw()` on the file you chose
3. Leave R open and check whether you can still rename the file - I am unable to