### PR TITLE
Avoid memory leak when error reading from file

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * New `write_file_raw()` function to write a raw vector to a file.
 
+* Fix memory leak in `read_lines()` (@ms609, #20)
+
 # brio 1.1.2
 
 * Input filenames are now automatically converted to UTF-8 from the native encoding (@gaborcsardi, #15)

--- a/src/read_lines.c
+++ b/src/read_lines.c
@@ -70,6 +70,8 @@ SEXP brio_read_lines(SEXP path, SEXP n) {
   size_t read_size = 0;
   while ((read_size = fread(read_buf, 1, READ_BUF_SIZE - 1, fp)) > 0) {
     if (read_size != READ_BUF_SIZE - 1 && ferror(fp)) {
+      free(line.data);
+      UNPROTECT(1); // out
       error(
           "Error reading from file: %s", Rf_translateChar(STRING_ELT(path, 0)));
     }

--- a/src/read_lines.c
+++ b/src/read_lines.c
@@ -71,7 +71,6 @@ SEXP brio_read_lines(SEXP path, SEXP n) {
   while ((read_size = fread(read_buf, 1, READ_BUF_SIZE - 1, fp)) > 0) {
     if (read_size != READ_BUF_SIZE - 1 && ferror(fp)) {
       free(line.data);
-      UNPROTECT(1); // out
       error(
           "Error reading from file: %s", Rf_translateChar(STRING_ELT(path, 0)));
     }


### PR DESCRIPTION
A [valgrind run](https://github.com/ms609/TreeTools/runs/3241160075?check_suite_focus=true#step:11:200) on a package calling brio reports:

```
==12202== 6,144 bytes in 6 blocks are definitely lost in loss record 691 of 4,437
==12202==    at 0x483B7F3: malloc (in [...]/vgpreload_memcheck-amd64-linux.so)
==12202==    by 0x22377B21: brio_read_lines (read_lines.c:62)
==12202==    by 0x49478BB: R_doDotCall (dotcode.c:601)
==12202==    by 0x498A6F9: bcEval (eval.c:7671)
==12202==    by 0x499DCF7: Rf_eval (eval.c:727)
==12202==    by 0x499FBBE: R_execClosure (eval.c:1897)
==12202==    by 0x49A0AB1: Rf_applyClosure (eval.c:1823)
==12202==    by 0x498B645: bcEval (eval.c:7083)
==12202==    by 0x499DCF7: Rf_eval (eval.c:727)
==12202==    by 0x499FBBE: R_execClosure (eval.c:1897)
==12202==    by 0x49A0AB1: Rf_applyClosure (eval.c:1823)
==12202==    by 0x498B645: bcEval (eval.c:7083)
```

[Edit:] I have [confirmed](https://github.com/ms609/TreeTools/pull/64/checks?check_run_id=3241615388) that this is fixed by this PR.